### PR TITLE
Cop whitelist

### DIFF
--- a/vrp/base.lua
+++ b/vrp/base.lua
@@ -52,6 +52,7 @@ CREATE TABLE IF NOT EXISTS vrp_users(
   last_login VARCHAR(255),
   whitelisted BOOLEAN,
   banned BOOLEAN,
+  cop BOOLEAN,
   CONSTRAINT pk_user PRIMARY KEY(id)
 );
 
@@ -78,7 +79,7 @@ CREATE TABLE IF NOT EXISTS vrp_srv_data(
 
 ]])
 
-local q_create_user = vRP.sql:prepare("INSERT INTO vrp_users(whitelisted,banned) VALUES(false,false)")
+local q_create_user = vRP.sql:prepare("INSERT INTO vrp_users(whitelisted,banned,cop) VALUES(false,false,false)")
 local q_add_identifier = vRP.sql:prepare("INSERT INTO vrp_user_ids(identifier,user_id) VALUES(@identifier,@user_id)")
 local q_userid_byidentifier = vRP.sql:prepare("SELECT user_id FROM vrp_user_ids WHERE identifier = @identifier")
 
@@ -95,6 +96,8 @@ local q_set_whitelisted = vRP.sql:prepare("UPDATE vrp_users SET whitelisted = @w
 local q_set_last_login = vRP.sql:prepare("UPDATE vrp_users SET last_login = @last_login WHERE id = @user_id")
 local q_get_last_login = vRP.sql:prepare("SELECT last_login FROM vrp_users WHERE id = @user_id")
 
+local q_set_cop_whitelist = vRP.sql:prepare("UPDATE vrp_users SET cop = @whitelisted WHERE id = @user_id")
+local q_get_cop_whitelist = vRP.sql:prepare("SELECT cop FROM vrp_users WHERE id = @user_id")
 -- init tables
 print("[vRP] init base tables")
 q_init:execute()
@@ -297,6 +300,27 @@ end
 
 function vRP.kick(source,reason)
   DropPlayer(source,reason)
+end
+
+--- sql
+function vRP.isCopWhitelisted(user_id)
+  q_get_cop_whitelist:bind("@user_id",user_id)
+  local r = q_get_cop_whitelist:query()
+  local v = false
+  if r:fetch() then
+    v = r:getValue(0)
+  end
+
+  r:close()
+  return v
+end
+
+--- sql
+function vRP.setCopWhitelisted(user_id,whitelisted)
+  q_set_cop_whitelist:bind("@user_id",user_id)
+  q_set_cop_whitelist:bind("@whitelisted",whitelisted)
+
+  q_set_cop_whitelist:execute()
 end
 
 -- tasks

--- a/vrp/cfg/groups.lua
+++ b/vrp/cfg/groups.lua
@@ -29,7 +29,9 @@ cfg.groups = {
     "player.custom_emote",
     "player.coords",
     "player.tptome",
-    "player.tpto"
+    "player.tpto",
+	"player.copWhitelist",
+	"player.copUnwhitelist"
   },
   -- the group user is auto added to all logged players
   ["user"] = {

--- a/vrp/cfg/police.lua
+++ b/vrp/cfg/police.lua
@@ -1,6 +1,8 @@
 
 local cfg = {}
 
+cfg.whitelist = true	--enable/disable whitelisted cops
+
 -- PC position
 cfg.pc = {1853.21, 3689.51, 34.2671}
 

--- a/vrp/modules/admin.lua
+++ b/vrp/modules/admin.lua
@@ -248,6 +248,28 @@ local function ch_noclip(player, choice)
   vRPclient.toggleNoclip(player, {})
 end
 
+local function ch_copWhitelist(player,choice)
+  local user_id = vRP.getUserId(player)
+  if user_id ~= nil and vRP.hasPermission(user_id,"player.copWhitelist") then
+    vRP.prompt(player,"User id to whitelist: ","",function(player,id)
+      id = tonumber(id)
+      vRP.setCopWhitelisted(id,true)
+      vRPclient.notify(player,{"Cop whitelisted user "..id})
+    end)
+  end
+end
+
+local function ch_copUnwhitelist(player,choice)
+  local user_id = vRP.getUserId(player)
+  if user_id ~= nil and vRP.hasPermission(user_id,"player.copUnwhitelist") then
+    vRP.prompt(player,"User id to un-whitelist: ","",function(player,id)
+      id = tonumber(id)
+      vRP.setCopWhitelisted(id,false)
+      vRPclient.notify(player,{"Cop un-whitelisted user "..id})
+    end)
+  end
+end
+
 AddEventHandler("vRP:buildMainMenu",function(player)
   local user_id = vRP.getUserId(player)
   if user_id ~= nil then
@@ -310,6 +332,12 @@ AddEventHandler("vRP:buildMainMenu",function(player)
       if vRP.hasPermission(user_id,"player.calladmin") then
         menu["@Call admin"] = {ch_calladmin}
       end
+	  if vRP.hasPermission(user_id,"player.copWhitelist") then
+		menu["@Whitelist Cop"] = {ch_copWhitelist}
+	  end 
+	  if vRP.hasPermission(user_id,"player.copUnwhitelist") then
+		menu["@Un-whitelist Cop"] = {ch_copUnwhitelist}
+	  end
 
       vRP.openMenu(player,menu)
     end}

--- a/vrp/modules/group.lua
+++ b/vrp/modules/group.lua
@@ -6,6 +6,7 @@
 
 -- api
 
+local police = require("resources/vrp/cfg/police")
 local cfg = require("resources/vrp/cfg/groups")
 local groups = cfg.groups
 local users = cfg.users
@@ -145,8 +146,18 @@ end
 local function ch_select(player,choice)
   local user_id = vRP.getUserId(player)
   if user_id ~= nil then
-    vRP.addUserGroup(user_id, choice)
-    vRP.closeMenu(player)
+	--if police check whitelist
+	if choice == "police" and police.whitelist then 
+		if vRP.isCopWhitelisted(user_id) then 
+			vRP.addUserGroup(user_id, choice)
+			vRP.closeMenu(player)
+		else
+			vRPclient.notify(player,{"You are not whitelisted for cop."})
+		end
+	else
+		vRP.addUserGroup(user_id, choice)
+		vRP.closeMenu(player)
+	end
   end
 end
 


### PR DESCRIPTION
- Requires players to be whitelisted before they can be cops.
- Admins can whitelist/unwhitelist through the admin menu
- Whitelisting can be disabled in police.cfg 