### PR TITLE
Reversible survival bar progression

### DIFF
--- a/vrp/cfg/survival.lua
+++ b/vrp/cfg/survival.lua
@@ -6,7 +6,6 @@ cfg = {
   overflow_damage_factor = 2,
   pvp = true,
   police = false,
-  max_value = 100,
   reverse = false
 }
 

--- a/vrp/cfg/survival.lua
+++ b/vrp/cfg/survival.lua
@@ -5,7 +5,9 @@ cfg = {
   hunger_per_minute = 1.25,
   overflow_damage_factor = 2,
   pvp = true,
-  police = false
+  police = false,
+  max_value = 100,
+  reverse = false
 }
 
 return cfg

--- a/vrp/modules/player_state.lua
+++ b/vrp/modules/player_state.lua
@@ -53,8 +53,8 @@ AddEventHandler("vRP:playerSpawn", function(user_id, source, first_spawn)
     -- notify last login
     SetTimeout(15000,function()vRPclient.notify(player,{lang.common.welcome({tmpdata.last_login})})end)
   else -- not first spawn (player died), don't load weapons, empty wallet, empty inventory
-    vRP.setHunger(user_id,0)
-    vRP.setThirst(user_id,0)
+    vRP.resetHunger(user_id)
+    vRP.resetThirst(user_id)
     vRP.clearInventory(user_id)
     data.phone_directory = {} -- clear phone directory after death
     vRP.setMoney(user_id,0)

--- a/vrp/modules/survival.lua
+++ b/vrp/modules/survival.lua
@@ -26,13 +26,13 @@ function vRP.setHunger(user_id,value)
   if data then
     data.hunger = value
     if data.hunger < 0 then data.hunger = 0
-    elseif data.hunger > cfg.max_value then data.hunger = cfg.max_value 
+    elseif data.hunger > 100 then data.hunger = 100
     end
 
     -- update bar
     local source = vRP.getUserSource(user_id)
     vRPclient.setProgressBarValue(source, {"vRP:hunger",data.hunger})
-    if (data.hunger >= cfg.max_value and not cfg.reverse) or (data.hunger <=0 and cfg.reverse) then
+    if (data.hunger >= 100 and not cfg.reverse) or (data.hunger <=0 and cfg.reverse) then
       vRPclient.setProgressBarText(source,{"vRP:hunger",lang.survival.starving()})
     else
       vRPclient.setProgressBarText(source,{"vRP:hunger",""})
@@ -45,13 +45,13 @@ function vRP.setThirst(user_id,value)
   if data then
     data.thirst = value
     if data.thirst < 0 then data.thirst = 0
-    elseif data.thirst > cfg.max_value then data.thirst = cfg.max_value 
+    elseif data.thirst > 100 then data.thirst = 100 
     end
 
     -- update bar
     local source = vRP.getUserSource(user_id)
     vRPclient.setProgressBarValue(source, {"vRP:thirst",data.thirst})
-    if (data.thirst >= cfg.max_value and not cfg.reverse) or (data.thirst <=0 and cfg.reverse) then
+    if (data.thirst >= 100 and not cfg.reverse) or (data.thirst <=0 and cfg.reverse) then
       vRPclient.setProgressBarText(source,{"vRP:thirst",lang.survival.thirsty()})
     else
       vRPclient.setProgressBarText(source,{"vRP:thirst",""})
@@ -61,7 +61,7 @@ end
 
 function vRP.resetHunger(user_id)
   if cfg.reverse then
-    vRP.setHunger(user_id, cfg.max_value)
+    vRP.setHunger(user_id, 100)
   else
     vRP.setHunger(user_id, 0)
   end
@@ -69,7 +69,7 @@ end
 
 function vRP.resetThirst(user_id)
   if cfg.reverse then
-    vRP.setThirst(user_id, cfg.max_value)
+    vRP.setThirst(user_id, 100)
   else
     vRP.setThirst(user_id, 0)
   end
@@ -82,26 +82,26 @@ function vRP.varyHunger(user_id, variation)
     local is_starving
     local overflow
     if cfg.reverse then
-      was_starving data.hunger <= 0
+      was_starving = data.hunger <= 0
       data.hunger = data.hunger - variation
       is_starving = data.hunger <= 0
 
       -- apply overflow as damage
       overflow = -data.hunger
     else
-      was_starving = data.hunger >= cfg.max_value
+      was_starving = data.hunger >= 100
       data.hunger = data.hunger + variation
-      is_starving = data.hunger >= cfg.max_value
+      is_starving = data.hunger >= 100
 
       -- apply overflow as damage
-      overflow = data.hunger-cfg.max_value
+      overflow = data.hunger - 100
     end
     if overflow > 0 then
       vRPclient.varyHealth(vRP.getUserSource(user_id),{-overflow*cfg.overflow_damage_factor})
     end
 
     if data.hunger < 0 then data.hunger = 0
-    elseif data.hunger > cfg.max_value then data.hunger = cfg.max_value 
+    elseif data.hunger > 100 then data.hunger = 100
     end
 
     -- set progress bar data
@@ -129,19 +129,19 @@ function vRP.varyThirst(user_id, variation)
       -- apply overflow as damage
       overflow = -data.thirst
     else
-      was_thirsty = data.thirst >= cfg.max_value
+      was_thirsty = data.thirst >= 100
       data.thirst = data.thirst + variation
-      is_thirsty = data.thirst >= cfg.max_value
+      is_thirsty = data.thirst >= 100
 
       -- apply overflow as damage
-      overflow = data.thirst-cfg.max_value
+      overflow = data.thirst - 100
     end
     if overflow > 0 then
       vRPclient.varyHealth(vRP.getUserSource(user_id),{-overflow*cfg.overflow_damage_factor})
     end
 
     if data.thirst < 0 then data.thirst = 0
-    elseif data.thirst > cfg.max_value then data.thirst = cfg.max_value 
+    elseif data.thirst > 100 then data.thirst = 100 
     end
 
     -- set progress bar data

--- a/vrp/modules/survival.lua
+++ b/vrp/modules/survival.lua
@@ -94,7 +94,7 @@ function vRP.varyHunger(user_id, variation)
       is_starving = data.hunger >= cfg.max_value
 
       -- apply overflow as damage
-      overflow = data.hunger-100
+      overflow = data.hunger-cfg.max_value
     end
     if overflow > 0 then
       vRPclient.varyHealth(vRP.getUserSource(user_id),{-overflow*cfg.overflow_damage_factor})
@@ -134,7 +134,7 @@ function vRP.varyThirst(user_id, variation)
       is_thirsty = data.thirst >= cfg.max_value
 
       -- apply overflow as damage
-      overflow = data.thirst-100
+      overflow = data.thirst-cfg.max_value
     end
     if overflow > 0 then
       vRPclient.varyHealth(vRP.getUserSource(user_id),{-overflow*cfg.overflow_damage_factor})

--- a/vrp/modules/survival.lua
+++ b/vrp/modules/survival.lua
@@ -26,13 +26,13 @@ function vRP.setHunger(user_id,value)
   if data then
     data.hunger = value
     if data.hunger < 0 then data.hunger = 0
-    elseif data.hunger > 100 then data.hunger = 100 
+    elseif data.hunger > cfg.max_value then data.hunger = cfg.max_value 
     end
 
     -- update bar
     local source = vRP.getUserSource(user_id)
     vRPclient.setProgressBarValue(source, {"vRP:hunger",data.hunger})
-    if data.hunger >= 100 then
+    if (data.hunger >= cfg.max_value and not cfg.reverse) or (data.hunger <=0 and cfg.reverse) then
       vRPclient.setProgressBarText(source,{"vRP:hunger",lang.survival.starving()})
     else
       vRPclient.setProgressBarText(source,{"vRP:hunger",""})
@@ -45,13 +45,13 @@ function vRP.setThirst(user_id,value)
   if data then
     data.thirst = value
     if data.thirst < 0 then data.thirst = 0
-    elseif data.thirst > 100 then data.thirst = 100 
+    elseif data.thirst > cfg.max_value then data.thirst = cfg.max_value 
     end
 
     -- update bar
     local source = vRP.getUserSource(user_id)
     vRPclient.setProgressBarValue(source, {"vRP:thirst",data.thirst})
-    if data.thirst >= 100 then
+    if (data.thirst >= cfg.max_value and not cfg.reverse) or (data.thirst <=0 and cfg.reverse) then
       vRPclient.setProgressBarText(source,{"vRP:thirst",lang.survival.thirsty()})
     else
       vRPclient.setProgressBarText(source,{"vRP:thirst",""})
@@ -59,21 +59,49 @@ function vRP.setThirst(user_id,value)
   end
 end
 
+function vRP.resetHunger(user_id)
+  if cfg.reverse then
+    vRP.setHunger(user_id, cfg.max_value)
+  else
+    vRP.setHunger(user_id, 0)
+  end
+end
+
+function vRP.resetThirst(user_id)
+  if cfg.reverse then
+    vRP.setThirst(user_id, cfg.max_value)
+  else
+    vRP.setThirst(user_id, 0)
+  end
+end
+
 function vRP.varyHunger(user_id, variation)
   local data = vRP.getUserDataTable(user_id)
   if data then
-    local was_starving = data.hunger >= 100
-    data.hunger = data.hunger + variation
-    local is_starving = data.hunger >= 100
+    local was_starving
+    local is_starving
+    local overflow
+    if cfg.reverse then
+      was_starving data.hunger <= 0
+      data.hunger = data.hunger - variation
+      is_starving = data.hunger <= 0
 
-    -- apply overflow as damage
-    local overflow = data.hunger-100
+      -- apply overflow as damage
+      overflow = -data.hunger
+    else
+      was_starving = data.hunger >= cfg.max_value
+      data.hunger = data.hunger + variation
+      is_starving = data.hunger >= cfg.max_value
+
+      -- apply overflow as damage
+      overflow = data.hunger-100
+    end
     if overflow > 0 then
       vRPclient.varyHealth(vRP.getUserSource(user_id),{-overflow*cfg.overflow_damage_factor})
     end
 
     if data.hunger < 0 then data.hunger = 0
-    elseif data.hunger > 100 then data.hunger = 100 
+    elseif data.hunger > cfg.max_value then data.hunger = cfg.max_value 
     end
 
     -- set progress bar data
@@ -90,18 +118,30 @@ end
 function vRP.varyThirst(user_id, variation)
   local data = vRP.getUserDataTable(user_id)
   if data then
-    local was_thirsty = data.thirst >= 100
-    data.thirst = data.thirst + variation
-    local is_thirsty = data.thirst >= 100
+    local was_thirsty
+    local is_thirsty
+    local overflow
+    if cfg.reverse
+      was_thirsty = data.thirst <= 0
+      data.thirst = data.thirst - variation
+      is_thirsty = data.thirst <= 0
 
-    -- apply overflow as damage
-    local overflow = data.thirst-100
+      -- apply overflow as damage
+      overflow = -data.thirst
+    else
+      was_thirsty = data.thirst >= cfg.max_value
+      data.thirst = data.thirst + variation
+      is_thirsty = data.thirst >= cfg.max_value
+
+      -- apply overflow as damage
+      overflow = data.thirst-100
+    end
     if overflow > 0 then
       vRPclient.varyHealth(vRP.getUserSource(user_id),{-overflow*cfg.overflow_damage_factor})
     end
 
     if data.thirst < 0 then data.thirst = 0
-    elseif data.thirst > 100 then data.thirst = 100 
+    elseif data.thirst > cfg.max_value then data.thirst = cfg.max_value 
     end
 
     -- set progress bar data


### PR DESCRIPTION
This commit adds functionality to let user change maximum hunger/thirst values via config, and to choose whether the bar is filling (as it does now and by default) or depleting.

There are two new variables in cfg/survival.lua: **max_value** that defaults as 100, and **reverse** that defaults as false. Setting **reverse** to true makes bar deplete instead of filling.

In modules/player_state.lua, calls to setHunger and setThirst with 0 on player respawn were replaced by calls to two new functions in modules/survival.lua, resetHunger and resetThirst.

In modules/survival.lua, two new functions were added as interfaces for player_state.lua, resetHunger and reset Thirst.
setHunger, setThirst, varyHunger and varyThirst were changed in order to account for the new variables. 