### PR TITLE
Survival bars update event

### DIFF
--- a/vrp/cfg/survival.lua
+++ b/vrp/cfg/survival.lua
@@ -5,7 +5,8 @@ cfg = {
   hunger_per_minute = 1.25,
   overflow_damage_factor = 2,
   pvp = true,
-  police = false
+  police = false,
+  disable = false
 }
 
 return cfg

--- a/vrp/modules/survival_reverse.lua
+++ b/vrp/modules/survival_reverse.lua
@@ -1,0 +1,38 @@
+local cfg = require("resources/vrp/cfg/survival")
+local lang = vRP.lang
+
+AddEventHandler("vRP:playerSpawn",function(user_id, source)
+  if cfg.disable then
+	local data = vRP.getUserDataTable(user_id)
+	vRPclient.setProgressBar(source,{"vRP:hunger","minimap",htxt,255,153,0,0})
+	vRPclient.setProgressBar(source,{"vRP:thirst","minimap",ttxt,0,125,255,0})
+	vRP.setHunger(user_id, data.hunger)
+	vRP.setThirst(user_id, data.thirst)
+  end
+end)
+
+AddEventHandler("vRP:updateHunger",function(user_id,value)
+  if cfg.disable then
+    local source = vRP.getUserSource(user_id)
+	value = 100 - value
+    vRPclient.setProgressBarValue(source,{"vRP:hunger",value})
+    if value <= 0 then
+      vRPclient.setProgressBarText(source,{"vRP:hunger",lang.survival.starving()})
+    else
+      vRPclient.setProgressBarText(source,{"vRP:hunger",""})
+    end
+  end
+end)
+
+AddEventHandler("vRP:updateThirst",function(user_id,value)
+  if cfg.disable then
+    local source = vRP.getUserSource(user_id)
+	value = 100 - value
+    vRPclient.setProgressBarValue(source,{"vRP:thirst",value})
+    if value <= 0 then
+      vRPclient.setProgressBarText(source,{"vRP:thirst",lang.survival.thirsty()})
+    else
+      vRPclient.setProgressBarText(source,{"vRP:thirst",""})
+    end
+  end
+end)


### PR DESCRIPTION
Added event listeners for hunger/thirst bars updating, with disable option built in.
Added "normalize" function to clean the code a bit.
Replaced bar updating code in all functions with event triggering.
Added option in "playerRespawn" listener to disable survival bars building.

Can attach my "survival_custom" module as an example if needed.