### PR TITLE
Menus event interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Also, player addresses are bound to the home cluster name, it means that if you 
   * [Inventory](#inventory)
   * [Item transformer](#item-transformer)
   * [GUI](#gui)
-     * [Registering choices to the main menu](#registering-choices-to-the-main-menu)
+     * [Registering choices to menus](#registering-choices-to-menus)
   * [Map](#map)
 * [Libs](#libs)
   * [Proxy](#proxy)
@@ -695,9 +695,11 @@ vRP.removeDiv(name)
 
 ```
 
-##### Registering choices to the main menu
+##### Registering choices to menus
 
-The main menu is generated using an event, this is useful to add special choices if needed.
+Menus are generated using events, this is useful to add special choices if needed.
+The full list of menu events from core modules is available in 'vrp/cfg/gui.lua'.
+IMPORTANT: menu registration via vRP.openMenu(source, menudata, event) is deprecated. Use vRP.constructMenu(source, menudata, event) instead.
 
 ```lua
 -- in another resource using the proxy interface
@@ -712,7 +714,7 @@ AddEventHandler("vRP:buildMainMenu",function(player)
   choices["My Choice"] = {fchoice,"My choice description."}
   choices["My Choice 2"] = {fchoice,"My choice 2 description."}
 
-  vRP.buildMainMenu({player,choices}) -- add choices to the player main menu
+  vRP.buildMainMenu(player,choices) -- add choices to the player main menu
 end)
 ```
 

--- a/README.md
+++ b/README.md
@@ -699,7 +699,7 @@ vRP.removeDiv(name)
 
 Menus are generated using events, this is useful to add special choices if needed.
 The full list of menu events from core modules is available in 'vrp/cfg/gui.lua'.
-IMPORTANT: menu registration via vRP.openMenu(source, menudata, event) is deprecated. Use vRP.constructMenu(source, menudata, event) instead.
+IMPORTANT: menu registration via vRP.openMenu(source, menudata) is deprecated. Use vRP.constructMenu(source, menudata, event) instead.
 
 ```lua
 -- in another resource using the proxy interface

--- a/vrp/cfg/gui.lua
+++ b/vrp/cfg/gui.lua
@@ -19,3 +19,33 @@ body{
 ]]
 
 return cfg
+
+--[[This is the full list of Menu building events available from vRP core modules:
+vRP:buildMainMenu
+vRP:buildATMMenu
+vRP:buildGarageMenu
+vRP:buildGarageOwnedMenu
+vRP:buildGarageBuyMenu
+vRP:buildGunshopMenu
+vRP:buildMarketMenu (you can get the exact Market name from the Menu data passed to the event)
+vRP:buildPhoneMenu
+vRP:buildPhoneDirectoryMenu
+vRP:buildPhoneContactMenu
+vRP:buildPhoneSMSMenu
+vRP:buildPhoneServiceMenu
+vRP:buildSkinshopMenu
+vRP:buildBusinessDirectoryMenu
+vRP:buildBusinessMenu
+vRP:buildCloacroomMenu
+vRP:buildEmoteMenu
+vRP:buildGroupMenu
+vRP:buildHouseMenu
+vRP:buildHouseEnterMenu
+vRP:buildIdentityMenu
+VRP:buildInventoryMenu
+vRP:buildInventoryItemMenu (you can get the exact Item name from the Menu data passed to the event)
+vRP:buildTransformerMenu
+vRP:buildInformerMenu
+vRP:buildPoliceMenu
+vRP:buildPoliceFineMenu
+]]--

--- a/vrp/modules/basic_atm.lua
+++ b/vrp/modules/basic_atm.lua
@@ -70,8 +70,8 @@ atm_menu[lang.atm.withdraw.title()] = {atm_choice_withdraw,lang.atm.withdraw.des
 local function atm_enter()
   local user_id = vRP.getUserId(source)
   if user_id ~= nil then
-    atm_menu[lang.atm.info.title()] = {function()end,lang.atm.info.bank({vRP.getBankMoney(user_id)})}
-    vRP.openMenu(source,atm_menu) 
+	atm_menu[lang.atm.info.title()] = {function()end,lang.atm.info.bank({vRP.getBankMoney(user_id)})}
+    vRP.constructMenu(source,atm_menu,"vRP:buildATMMenu") 
   end
 end
 

--- a/vrp/modules/basic_garage.lua
+++ b/vrp/modules/basic_garage.lua
@@ -43,7 +43,7 @@ for group,vehicles in pairs(vehicle_groups) do
       local kitems = {}
       local submenu = {name=lang.garage.title({lang.garage.owned.title()}), css={top="75px",header_color="rgba(255,125,0,0.75)"}}
       submenu.onclose = function()
-        vRP.openMenu(player,menu)
+        vRP.constructMenu(player,menu,"vRP:buildGarageMenu")
       end
 
       local choose = function(player, choice)
@@ -70,7 +70,7 @@ for group,vehicles in pairs(vehicle_groups) do
         end
       end
 
-      vRP.openMenu(player,submenu)
+      vRP.constructMenu(player,submenu,"vRP:buildGarageOwnedMenu")
     end
   end,lang.garage.owned.description()}
 
@@ -81,7 +81,7 @@ for group,vehicles in pairs(vehicle_groups) do
       local kitems = {}
       local submenu = {name=lang.garage.title({lang.garage.buy.title()}), css={top="75px",header_color="rgba(255,125,0,0.75)"}}
       submenu.onclose = function()
-        vRP.openMenu(player,menu)
+        vRP.constructMenu(player,menu,"vRP:buildGarageMenu")
       end
 
       local choose = function(player, choice)
@@ -118,7 +118,7 @@ for group,vehicles in pairs(vehicle_groups) do
         end
       end
 
-      vRP.openMenu(player,submenu)
+      vRP.constructMenu(player,submenu,"vRP:buildGarageBuyMenu")
     end
   end,lang.garage.buy.description()}
 
@@ -143,7 +143,7 @@ local function build_client_garages(source)
           if user_id ~= nil and (gcfg.permission == nil or vRP.hasPermission(user_id,gcfg.permission)) then
             local menu = garage_menus[gtype]
             if menu then
-              vRP.openMenu(player,menu)
+              vRP.constructMenu(player,menu,"vRP:buildGarageMenu")
             end
           end
         end
@@ -191,7 +191,6 @@ veh_actions[lang.vehicle.detach_trailer.title()] = {function(user_id,player,vtyp
   vRPclient.vc_detachTrailer(player, {vtype})
 end, lang.vehicle.detach_trailer.description()}
 
-
 local function ch_vehicle(player,choice)
   local user_id = vRP.getUserId(player)
   if user_id ~= nil then
@@ -205,7 +204,7 @@ local function ch_vehicle(player,choice)
           menu[k] = {function(player,choice) v[1](user_id,player,vtype,name) end, v[2]}
         end
 
-        vRP.openMenu(player,menu)
+        vRP.constructMenu(player,menu,"vRP:buildVehicleMenu")
       else
         vRPclient.notify(player,{lang.vehicle.no_owned_near()})
       end

--- a/vrp/modules/basic_gunshop.lua
+++ b/vrp/modules/basic_gunshop.lua
@@ -81,7 +81,7 @@ local function build_client_gunshops(source)
         local function gunshop_enter()
           local user_id = vRP.getUserId(source)
           if user_id ~= nil and (gcfg.permission == nil or vRP.hasPermission(user_id,gcfg.permission)) then
-            vRP.openMenu(source,menu) 
+            vRP.constructMenu(source,menu,"vRP:buildGunshopMenu") 
           end
         end
 

--- a/vrp/modules/basic_market.lua
+++ b/vrp/modules/basic_market.lua
@@ -89,7 +89,7 @@ local function build_client_markets(source)
         local function market_enter()
           local user_id = vRP.getUserId(source)
           if user_id ~= nil and (gcfg.permission == nil or vRP.hasPermission(user_id,gcfg.permission)) then
-            vRP.openMenu(source,menu) 
+            vRP.constructMenu(source,menu,"vRP:buildMarketMenu") 
           end
         end
 

--- a/vrp/modules/basic_phone.lua
+++ b/vrp/modules/basic_phone.lua
@@ -211,7 +211,7 @@ local function ch_directory(player,choice)
       emenu.onclose = function() ch_directory(player,lang.phone.directory.title()) end 
 
       -- open mnu
-      vRP.openMenu(player, emenu)
+      vRP.constructMenu(player, emenu, "vRP:buildPhoneContactMenu")
     end
 
     menu[lang.phone.directory.add.title()] = {ch_add}
@@ -224,7 +224,7 @@ local function ch_directory(player,choice)
     -- menu.onclose = function(player) vRP.openMenu(player, phone_menu) end
 
     -- open menu
-    vRP.openMenu(player,menu)
+    vRP.constructMenu(player,menu,"vRP:buildPhoneDirectoryMenu")
   end
 end
 
@@ -253,10 +253,10 @@ local function ch_sms(player, choice)
     end
 
     -- nest menu
-    menu.onclose = function(player) vRP.openMenu(player, phone_menu) end
+    menu.onclose = function(player) vRP.constructMenu(player,phone_menu,"vRP:buildPhoneMenu") end
 
     -- open menu
-    vRP.openMenu(player,menu)
+    vRP.constructMenu(player,menu,"vRP:buildPhoneSMSMenu")
   end
 end
 
@@ -264,7 +264,7 @@ end
 local service_menu = {name=lang.phone.service.title(),css={top="75px",header_color="rgba(0,125,255,0.75)"}}
 
 -- nest menu
-service_menu.onclose = function(player) vRP.openMenu(player, phone_menu) end
+service_menu.onclose = function(player) vRP.constructMenu(player,phone_menu,"vRP:buildPhoneMenu") end
 
 local function ch_service_alert(player,choice) -- alert a service
   local service = services[choice]
@@ -283,7 +283,7 @@ for k,v in pairs(services) do
 end
 
 local function ch_service(player, choice)
-  vRP.openMenu(player,service_menu)
+  vRP.constructMenu(player,service_menu,"vRP:buildPhoneServiceMenu")
 end
 
 phone_menu[lang.phone.directory.title()] = {ch_directory,lang.phone.directory.description()}
@@ -294,7 +294,7 @@ phone_menu[lang.phone.service.title()] = {ch_service,lang.phone.service.descript
 
 AddEventHandler("vRP:buildMainMenu",function(player) 
   local choices = {}
-  choices[lang.phone.title()] = {function() vRP.openMenu(player,phone_menu) end}
+  choices[lang.phone.title()] = {function() vRP.constructMenu(player,phone_menu,"vRP:buildPhoneMenu") end}
 
   local user_id = vRP.getUserId(player)
   if user_id ~= nil and vRP.hasPermission(user_id, "player.phone") then

--- a/vrp/modules/basic_skinshop.lua
+++ b/vrp/modules/basic_skinshop.lua
@@ -131,7 +131,7 @@ function vRP.openSkinshop(source,parts)
       end
 
       -- open menu
-      vRP.openMenu(source,menudata)
+      vRP.constructMenu(source,menudata,"vRP:buildSkinshopMenu")
     end)
   end
 end

--- a/vrp/modules/business.lua
+++ b/vrp/modules/business.lua
@@ -89,7 +89,7 @@ local function open_business_directory(player,page) -- open business directory w
   menu[lang.business.directory.dnext()] = {function() open_business_directory(player,page+1) end}
   menu[lang.business.directory.dprev()] = {function() open_business_directory(player,page-1) end}
 
-  vRP.openMenu(player,menu)
+  vRP.constructMenu(player,menu,"vRP:buildBusinessDirectoryMenu")
 end
 
 local function business_enter()
@@ -184,7 +184,7 @@ local function business_enter()
     end,lang.business.directory.description()}
 
     -- open menu
-    vRP.openMenu(source,menu) 
+    vRP.constructMenu(source,menu,"vRP:buildBusinessMenu") 
   end
 end
 

--- a/vrp/modules/cloakroom.lua
+++ b/vrp/modules/cloakroom.lua
@@ -112,7 +112,7 @@ local function build_client_points(source)
             end
           end
 
-          vRP.openMenu(source,menu)
+          vRP.constructMenu(source,menu,"vRP:buildCloakroomMenu")
         end
       end
 

--- a/vrp/modules/emotes.lua
+++ b/vrp/modules/emotes.lua
@@ -30,6 +30,6 @@ end
 
 AddEventHandler("vRP:buildMainMenu",function(player) 
   local choices = {}
-  choices[lang.emotes.title()] = {function() vRP.openMenu(player,menu) end}
+  choices[lang.emotes.title()] = {function() vRP.constructMenu(player,menu,"vRP:buildEmoteMenu") end}
   vRP.buildMainMenu(player,choices)
 end)

--- a/vrp/modules/group.lua
+++ b/vrp/modules/group.lua
@@ -178,7 +178,7 @@ local function build_client_selectors(source)
         local function selector_enter()
           local user_id = vRP.getUserId(source)
           if user_id ~= nil and (gcfg.permission == nil or vRP.hasPermission(user_id,gcfg.permission)) then
-            vRP.openMenu(source,menu) 
+            vRP.constructMenu(source,menu,"vRP:buildGroupMenu") 
           end
         end
 

--- a/vrp/modules/gui.lua
+++ b/vrp/modules/gui.lua
@@ -85,11 +85,10 @@ local menu_builds = {}
 
 --any resource in need of a menu calls this function instead of vRP.openMenu
 
-function vRP.constructMenu(source, menudata, event, ...) 
-  local payload = {...}
+function vRP.constructMenu(source, menudata, event)
   menu_builds[source] = menudata
 
-  TriggerEvent(event,source,{...}) -- all resources can add choices to the menu via argument event handlers
+  TriggerEvent(event,source) -- all resources can add choices to the menu via argument event handlers
 
   vRP.openMenu(source,menudata) -- open the generated menu
 end

--- a/vrp/modules/gui.lua
+++ b/vrp/modules/gui.lua
@@ -79,28 +79,55 @@ function vRP.request(source,text,time,cb_ok)
   end)
 end
 
--- MAIN MENU
+-- MENU GENERATOR
 
-local main_menu_builds = {}
+local menu_builds = {}
 
--- open the player main menu
-function vRP.openMainMenu(source)
-  local menudata = {name="Main menu",css={top="75px",header_color="rgba(0,125,255,0.75)"}}
-  main_menu_builds[source] = menudata
+--any resource in need of a menu calls this function instead of vRP.openMenu
 
-  TriggerEvent("vRP:buildMainMenu",source) -- all resources can add choices to the menu using vRP.buildMainMenu(player,choices)
+function vRP.constructMenu(source, menudata, event, ...) 
+  local payload = {...}
+  menu_builds[source] = menudata
+
+  TriggerEvent(event,source,{...}) -- all resources can add choices to the menu via argument event handlers
 
   vRP.openMenu(source,menudata) -- open the generated menu
 end
 
--- called inside a vRP:buildMainMenu event to build the player main menu (to add choices)
-function vRP.buildMainMenu(source,choices)
-  local menudata = main_menu_builds[source]
+-- called inside a menu construction event to build the menu
+function vRP.buildMenu(source,choices)
+  local menudata = menu_builds[source]
   if menudata ~= nil then
     for k,v in pairs(choices) do
       menudata[k] = v
     end
   end
+end
+
+-- MAIN MENU deprecated interface, for backward compatibility
+
+--local main_menu_builds = {}
+
+-- open the player main menu
+function vRP.openMainMenu(source)
+  local menudata = {name="Main menu",css={top="75px",header_color="rgba(0,125,255,0.75)"}}
+  vRP.constructMenu(source,menudata,"vRP:buildMainMenu")
+  --[[main_menu_builds[source] = menudata
+
+  TriggerEvent("vRP:buildMainMenu",source) -- all resources can add choices to the menu using vRP.buildMainMenu(player,choices)
+
+  vRP.openMenu(source,menudata) -- open the generated menu]]--
+end
+
+-- called inside a vRP:buildMainMenu event to build the player main menu (to add choices)
+function vRP.buildMainMenu(source,choices)
+  vRP.buildMenu(source,choices)
+  --[[local menudata = main_menu_builds[source]
+  if menudata ~= nil then
+    for k,v in pairs(choices) do
+      menudata[k] = v
+    end
+  end]]--
 end
 
 -- SERVER TUNNEL API

--- a/vrp/modules/home.lua
+++ b/vrp/modules/home.lua
@@ -206,7 +206,7 @@ local function enter_slot(user_id,player,stype,sid) -- called when a player ente
   -- build the slot entry menu marker/area
 
   local function entry_enter(player,area)
-    vRP.openMenu(player,menu)
+    vRP.constructMenu(player,menu,"vRP:buildHouseEnterMenu")
   end
 
   local function entry_leave(player,area)
@@ -330,7 +330,7 @@ local function build_client_homes(source)
       local function entry_enter(player,area)
         local user_id = vRP.getUserId(player)
         if user_id ~= nil and (v.permission == nil or vRP.hasPermission(user_id,v.permission)) then
-          vRP.openMenu(source,build_entry_menu(user_id, k))
+          vRP.constructMenu(source,build_entry_menu(user_id, k),"vRP:buildHouseMenu")
         end
       end
 

--- a/vrp/modules/identity.lua
+++ b/vrp/modules/identity.lua
@@ -197,7 +197,7 @@ cityhall_menu[lang.cityhall.identity.title()] = {ch_identity,lang.cityhall.ident
 local function cityhall_enter()
   local user_id = vRP.getUserId(source)
   if user_id ~= nil then
-    vRP.openMenu(source,cityhall_menu) 
+    vRP.constructMenu(source,cityhall_menu,"vRP:buildIdentityMenu")
   end
 end
 

--- a/vrp/modules/inventory.lua
+++ b/vrp/modules/inventory.lua
@@ -199,7 +199,7 @@ function vRP.openInventory(source)
             end
 
             -- open menu
-            vRP.openMenu(source,submenudata)
+            vRP.constructMenu(source,submenudata,"vRP:buildInventoryItemMenu")
           end
         end
       end
@@ -214,7 +214,7 @@ function vRP.openInventory(source)
       end
 
       -- open menu
-      vRP.openMenu(source,menudata)
+      vRP.constructMenu(source,menudata,"vRP:buildInventoryMenu")
     end
   end
 end

--- a/vrp/modules/item_transformer.lua
+++ b/vrp/modules/item_transformer.lua
@@ -145,7 +145,7 @@ function vRP.setItemTransformer(name,itemtr)
   tr.enter = function(player,area)
     local user_id = vRP.getUserId(player)
     if user_id ~= nil and (itemtr.permission == nil or vRP.hasPermission(user_id,itemtr.permission)) then
-      vRP.openMenu(player, tr.menu) -- open menu
+      vRP.constructMenu(player, tr.menu, "vRP:buildTransformerMenu") -- open menu
     end
   end
 
@@ -305,7 +305,7 @@ end
 local function informer_enter()
   local user_id = vRP.getUserId(source)
   if user_id ~= nil then
-    vRP.openMenu(source,informer_menu) 
+    vRP.constructMenu(source,informer_menu,"vRP:buildInformerMenu") 
   end
 end
 

--- a/vrp/modules/police.lua
+++ b/vrp/modules/police.lua
@@ -151,7 +151,7 @@ end
 local function pc_enter(source,area)
   local user_id = vRP.getUserId(source)
   if user_id ~= nil and vRP.hasPermission(user_id,"police.pc") then
-    vRP.openMenu(source,menu_pc)
+    vRP.constructMenu(source,menu_pc,"vRP:buildPolicePCMenu")
   end
 end
 
@@ -457,7 +457,7 @@ local choice_fine = {function(player, choice)
         end
 
         -- open menu
-        vRP.openMenu(player, menu)
+        vRP.constructMenu(player, menu,"vRP:buildPoliceFineMenu")
       else
         vRPclient.notify(player,{lang.common.no_player_near()})
       end


### PR DESCRIPTION
So I decided to create a module that adds a "New Phone" menu point to the City Hall, to let players on my server use their real phone numbers. Or dream ones. But how discouraged I was to realize that you can only add choices to the main menu! Then I thought, 'Hey, what if one just makes all menus build in the same fashion the main menu does?'

Here it is. This commit is 100% backward (and forward, for that matter) compatible. Although, all core modules are updated to call new vRP.constructMenu(source, menudata, event) function, to let user resources register choices to any menus. I think this is a good practice for future use, as it makes the framework highly customizeable.