### PR TITLE
Fix for side detection on current FXServer version

### DIFF
--- a/vrp/lib/utils.lua
+++ b/vrp/lib/utils.lua
@@ -2,7 +2,7 @@
 -- it will create module, SERVER, CLIENT, async, class...
 
 -- side detection
-SERVER = not IsVehicleEngineStarting
+SERVER = IsDuplicityVersion()
 CLIENT = not SERVER
 
 -- table.maxn replacement


### PR DESCRIPTION
## Bug

utils.lua is incorrectly recognizing what side SERVER/CLIENT it is on.

## Reproduce the Problem

Logging onto the server will currently hang you on character loading. Server will throw error "TriggerRemoteEvent was nil"

## Specifications

  - FXServer Version: 1552-8e2468eb15caacdf739ff893d7e2cd83dc6f6e0a
  - Platform: Linux

## Fix

Changing the detection method to return value of IsDuplicityVersion(). Suggestion from pull request #559 by Disquse